### PR TITLE
Add GitHub Actions workflow for Android APK build

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,28 @@
+name: Build Android APK
+
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+jobs:
+  build-android:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm test
+      - uses: expo/expo-github-action@v8
+        with:
+          expo-version: 5.x
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+      - run: eas build --platform android --profile preview --non-interactive
+      - run: eas build:download --platform android --profile preview --path app.apk
+      - uses: actions/upload-artifact@v3
+        with:
+          name: app-apk
+          path: app.apk

--- a/eas.json
+++ b/eas.json
@@ -1,0 +1,12 @@
+{
+  "cli": {
+    "version": ">= 3.13.0"
+  },
+  "build": {
+    "preview": {
+      "android": {
+        "buildType": "apk"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build Android APK with Expo's EAS
- define `eas.json` profile to generate APK output

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aad413f374832fa1d51305549a7f17